### PR TITLE
feat: Implement Role-based Access Control

### DIFF
--- a/app/Console/Commands/MakeUser.php
+++ b/app/Console/Commands/MakeUser.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Spatie\Permission\Models\Role;
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\spin;
+
+class MakeUser extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'user:create';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new user';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $name = text(
+            label: 'Name',
+        );
+
+        $email = text(
+            label: 'Email',
+            required: true,
+            validate: function (string $email): ?string {
+                if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                    return "The email $email is not valid";
+                }
+
+                if (User::where('email', $email)->exists()) {
+                    return "The email $email is already taken";
+                }
+
+                return null;
+            }
+        );
+
+        $roles = multiselect(
+            label: 'Role',
+            options: Role::pluck('name', 'id'),
+        );
+
+        $password = password(
+            label: 'Password',
+            required: true,
+            validate: fn(string $value) => match(true){
+                strlen($value) < 8 => "The password must be at least 8 characters long",
+                !preg_match('/[A-Z]/', $value) => "The password must contain at least one uppercase letter",
+                !preg_match('/[a-z]/', $value) => "The password must contain at least one lowercase letter",
+                !preg_match('/[0-9]/', $value) => "The password must contain at least one number",
+                default => null
+            }
+        );
+
+        password(
+            label: 'Confirm password',
+            required: true,
+            validate: function (string $value) use ($password): ?string {
+                if ($value !== $password) {
+                    return "The password confirmation does not match";
+                }
+
+                return null;
+            }
+        );
+
+
+        spin(
+            fn () => User::create([
+                'name' => $name,
+                'email' => $email,
+                'password' => bcrypt($password),
+            ])->assignRole($roles),
+            'Creating user...'
+        );
+
+        $this->info("User created with email: $email");
+    }
+}

--- a/app/Enums/PermissionEnum.php
+++ b/app/Enums/PermissionEnum.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Enums;
+
+enum PermissionEnum: string {
+    case ACCESS_USERS = "access users";
+    case CREATE_USERS = "create users";
+    case EDIT_USERS = "edit users";
+    case DELETE_USERS = "delete users";
+    case ACCESS_ALL_REPORTS = "access all reports";
+    case ACCESS_OWN_REPORTS = "access own reports";
+    case CREATE_REPORTS = "create reports";
+    case EDIT_ALL_REPORTS = "edit all reports";
+    case EDIT_OWN_REPORTS = "edit own reports";
+    case DELETE_ALL_REPORTS = "delete all reports";
+    case DELETE_OWN_REPORTS = "delete own reports";
+    case ACCESS_ROLES = "access roles";
+    case CREATE_ROLES = "create roles";
+    case EDIT_ROLES = "edit roles";
+    case DELETE_ROLES = "delete roles";
+    case ASSIGN_ROLES = "assign roles";
+    case ACCESS_PERMISSIONS = "access permissions";
+    case ASSIGN_PERMISSIONS = "assign permissions";
+}

--- a/app/Enums/PermissionsEnum.php
+++ b/app/Enums/PermissionsEnum.php
@@ -22,29 +22,4 @@ enum PermissionsEnum: string {
     case ASSIGN_ROLES = "assign roles";
     case ACCESS_PERMISSIONS = "access permissions";
     case ASSIGN_PERMISSIONS = "assign permissions";
-
-    public static function toArray(): array
-    {
-        return [
-            self::ADMIN_ACCESS,
-            self::ACCESS_USERS,
-            self::CREATE_USERS,
-            self::EDIT_USERS,
-            self::DELETE_USERS,
-            self::ACCESS_ALL_REPORTS,
-            self::ACCESS_OWN_REPORTS,
-            self::CREATE_REPORTS,
-            self::EDIT_ALL_REPORTS,
-            self::EDIT_OWN_REPORTS,
-            self::DELETE_ALL_REPORTS,
-            self::DELETE_OWN_REPORTS,
-            self::ACCESS_ROLES,
-            self::CREATE_ROLES,
-            self::EDIT_ROLES,
-            self::DELETE_ROLES,
-            self::ASSIGN_ROLES,
-            self::ACCESS_PERMISSIONS,
-            self::ASSIGN_PERMISSIONS,
-        ];
-    }
 }

--- a/app/Enums/PermissionsEnum.php
+++ b/app/Enums/PermissionsEnum.php
@@ -22,4 +22,29 @@ enum PermissionsEnum: string {
     case ASSIGN_ROLES = "assign roles";
     case ACCESS_PERMISSIONS = "access permissions";
     case ASSIGN_PERMISSIONS = "assign permissions";
+
+    public static function toArray(): array
+    {
+        return [
+            self::ADMIN_ACCESS,
+            self::ACCESS_USERS,
+            self::CREATE_USERS,
+            self::EDIT_USERS,
+            self::DELETE_USERS,
+            self::ACCESS_ALL_REPORTS,
+            self::ACCESS_OWN_REPORTS,
+            self::CREATE_REPORTS,
+            self::EDIT_ALL_REPORTS,
+            self::EDIT_OWN_REPORTS,
+            self::DELETE_ALL_REPORTS,
+            self::DELETE_OWN_REPORTS,
+            self::ACCESS_ROLES,
+            self::CREATE_ROLES,
+            self::EDIT_ROLES,
+            self::DELETE_ROLES,
+            self::ASSIGN_ROLES,
+            self::ACCESS_PERMISSIONS,
+            self::ASSIGN_PERMISSIONS,
+        ];
+    }
 }

--- a/app/Enums/PermissionsEnum.php
+++ b/app/Enums/PermissionsEnum.php
@@ -2,7 +2,8 @@
 
 namespace App\Enums;
 
-enum PermissionEnum: string {
+enum PermissionsEnum: string {
+    case ADMIN_ACCESS = "admin access";
     case ACCESS_USERS = "access users";
     case CREATE_USERS = "create users";
     case EDIT_USERS = "edit users";

--- a/app/Enums/RolesEnum.php
+++ b/app/Enums/RolesEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum RolesEnum: string {
+    case SUPER_ADMIN = 'super-admin';
+    case ADMIN = 'admin';
+    case USER = 'user';
+}

--- a/app/Http/Controllers/Admin/PermissionController.php
+++ b/app/Http/Controllers/Admin/PermissionController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class PermissionController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/Admin/PermissionController.php
+++ b/app/Http/Controllers/Admin/PermissionController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 use Inertia\Response;
+use Spatie\Permission\Models\Permission;
 
 class PermissionController extends Controller
 {
@@ -20,7 +21,7 @@ class PermissionController extends Controller
         }
 
         return Inertia::render('Permissions/Index', [
-            'permissions' => PermissionsEnum::toArray(),
+            'permissions' => Permission::withCount("roles")->orderBy('name', 'ASC')->get()
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/PermissionController.php
+++ b/app/Http/Controllers/Admin/PermissionController.php
@@ -2,64 +2,25 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\PermissionsEnum;
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
 
 class PermissionController extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index() : Response|RedirectResponse
     {
-        //
-    }
+        if (!auth()->user()->can(PermissionsEnum::ACCESS_PERMISSIONS->value)) {
+            return redirect()->route('home')->with('error', 'You do not have permission to access this page.');
+        }
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return Inertia::render('Permissions/Index', [
+            'permissions' => PermissionsEnum::toArray(),
+        ]);
     }
 }

--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class RoleController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -3,38 +3,59 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Inertia\Response;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 class RoleController extends Controller
 {
+
+    public function __construct()
+    {
+        $this->authorizeResource(Role::class, 'role');
+    }
+
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(): Response
     {
-        //
+        return inertia('Roles/Index', [
+            'roles' => Role::all()
+        ]);
     }
 
     /**
      * Show the form for creating a new resource.
      */
-    public function create()
+    public function create(): Response
     {
-        //
+        return inertia('Roles/Create', [
+            'permissions' => Permission::all()
+        ]);
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(Request $request): RedirectResponse
     {
-        //
+//        $role = Role::create($request->validate([
+//            'name' => ['required', 'string', 'max:255'],
+//            'permissions' => ['array']
+//        ]));
+//
+//        $role->syncPermissions($request->permissions);
+
+        return redirect()->route('roles.index');
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(string $id)
+    public function show(Role $role)
     {
         //
     }
@@ -42,24 +63,28 @@ class RoleController extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(string $id)
+    public function edit(Role $role): Response
     {
-        //
+        return inertia('Roles/Edit', [
+            'role' => $role->load('permissions'),
+            'permissions' => Permission::all()
+        ]);
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(Request $request, Role $role): RedirectResponse
     {
-        //
+        return redirect()->route('roles.index');
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id)
+    public function destroy(Role $role): RedirectResponse
     {
-        //
+        $role->delete();
+        return redirect()->route('roles.index')->with('success', 'Role deleted.');
     }
 }

--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -44,6 +44,11 @@ class RoleController extends Controller
      */
     public function store(StoreRoleRequest $request): RedirectResponse
     {
+        if (Role::where('name', $request->name)->exists()) {
+            return redirect()->route('roles.create')
+                ->withErrors(['name' => 'The role name already exists. Please choose a different name.']);
+        }
+
         Role::create(['name' => $request->name])->syncPermissions($request->permissions);
         return redirect()->route('roles.index');
     }
@@ -74,6 +79,12 @@ class RoleController extends Controller
      */
     public function update(UpdateRoleRequest $request, Role $role): RedirectResponse
     {
+        // Check if the role name already exists except for the current role being updated
+        if (Role::where('name', $request->name)->where('id', '!=', $role->id)->exists()) {
+            return redirect()->route('roles.edit', $role)
+                ->withErrors(['name' => 'The role name already exists. Please choose a different name.']);
+        }
+
         $role->update(['name' => $request->name]);
         $role->syncPermissions($request->permissions);
         return redirect()->route('roles.index')->with('success', 'Role updated.');

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Enums\RolesEnum;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
@@ -42,6 +43,7 @@ class RegisteredUserController extends Controller
             'email' => $request->email,
             'password' => Hash::make($request->password),
         ]);
+        $user->assignRole(RolesEnum::USER);
 
         event(new Registered($user));
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -29,6 +29,7 @@ class ReportController extends Controller
     public function index(): Response
     {
         $reports = Report::query()
+            ->where('user_id', auth()->user()->id)
             ->when(request('search'), function ($query, $search) {
                 $this->applySearchFilter($query, $search);
             })
@@ -67,6 +68,8 @@ class ReportController extends Controller
      */
     public function store(StoreReportRequest $request): RedirectResponse
     {
+        $this->authorize('create', Report::class);
+
         $report = Report::create([
             'title' => $request->title,
             'description' => $request->description,
@@ -94,6 +97,8 @@ class ReportController extends Controller
      */
     public function create(): Response
     {
+        $this->authorize('create', Report::class);
+
         return Inertia::render('Reports/Create', [
             'attachments' => Attachment::where('user_id', auth()->user()->id)->get(),
         ]);
@@ -104,6 +109,8 @@ class ReportController extends Controller
      */
     public function show(Report $report): Response
     {
+        $this->authorize('view', $report);
+
         return Inertia::render('Reports/Show', [
             'report' => $report->load('users', 'comments', "attachments", "tags"),
         ]);
@@ -114,6 +121,8 @@ class ReportController extends Controller
      */
     public function edit(Report $report): Response
     {
+        $this->authorize('update', $report);
+
         return Inertia::render('Reports/Edit', [
             'report' => $report->load('users', 'attachments', "tags"),
             'attachments' => Attachment::where('user_id', auth()->user()->id)->get(),
@@ -125,6 +134,8 @@ class ReportController extends Controller
      */
     public function update(UpdateReportRequest $request, Report $report): RedirectResponse
     {
+        $this->authorize('update', $report);
+
         $report->update([
             'title' => $request->title,
             'description' => $request->description,
@@ -152,6 +163,8 @@ class ReportController extends Controller
      */
     public function destroy(Report $report): RedirectResponse
     {
+        $this->authorize('delete', $report);
+
         $report->delete();
 
         return redirect()->route('reports.index')->with('success', 'Report deleted.');

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -66,5 +66,9 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+        'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
+        'admin' => \App\Http\Middleware\AdminCheck::class,
     ];
 }

--- a/app/Http/Middleware/AdminCheck.php
+++ b/app/Http/Middleware/AdminCheck.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminCheck
+{reports
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if(Auth::check()) {
+            if(Auth::user()->can('admin access')) {
+                return $next($request);
+            } else {
+                return redirect()->route('home');
+            }
+        } else {
+            return redirect()->route('home');
+        }
+    }
+}

--- a/app/Http/Middleware/AdminCheck.php
+++ b/app/Http/Middleware/AdminCheck.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class AdminCheck
-{reports
+{
     /**
      * Handle an incoming request.
      *

--- a/app/Http/Middleware/AdminCheck.php
+++ b/app/Http/Middleware/AdminCheck.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Enums\PermissionsEnum;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -12,12 +13,14 @@ class AdminCheck
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param Request $request
+     * @param Closure(Request): (Response) $next
+     * @return Response
      */
     public function handle(Request $request, Closure $next): Response
     {
         if(Auth::check()) {
-            if(Auth::user()->can('admin access')) {
+            if(Auth::user()->can(PermissionsEnum::ADMIN_ACCESS->value)) {
                 return $next($request);
             } else {
                 return redirect()->route('home');

--- a/app/Http/Requests/StoreReportRequest.php
+++ b/app/Http/Requests/StoreReportRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreReportRequest extends FormRequest
@@ -17,12 +18,13 @@ class StoreReportRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array|string>
      */
     public function rules(): array
     {
         return [
             'title' => ['required', 'min:20', 'max:255'],
+            'status' => ['required'],
         ];
     }
 }

--- a/app/Http/Requests/StoreRoleRequest.php
+++ b/app/Http/Requests/StoreRoleRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRoleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return (bool)auth()->user();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', 'min:3'],
+            'permissions' => ['array']
+        ];
+    }
+}

--- a/app/Http/Requests/StoreRoleRequest.php
+++ b/app/Http/Requests/StoreRoleRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreRoleRequest extends FormRequest
 {
@@ -23,7 +24,13 @@ class StoreRoleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255', 'min:3'],
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                'min:3',
+                Rule::notIn(['super-admin']) // Ensure name is not 'super-admin'
+            ],
             'permissions' => ['array']
         ];
     }

--- a/app/Http/Requests/UpdateReportRequest.php
+++ b/app/Http/Requests/UpdateReportRequest.php
@@ -23,6 +23,7 @@ class UpdateReportRequest extends FormRequest
     {
         return [
             'title' => ['required', 'max:255'],
+            'status' => ['required'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateRoleRequest.php
+++ b/app/Http/Requests/UpdateRoleRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateRoleRequest extends FormRequest
 {
@@ -23,7 +24,13 @@ class UpdateRoleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255', 'min:3'],
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                'min:3',
+                Rule::notIn(['super-admin']) // Ensure name is not 'super-admin'
+            ],
             'permissions' => ['array']
         ];
     }

--- a/app/Http/Requests/UpdateRoleRequest.php
+++ b/app/Http/Requests/UpdateRoleRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRoleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return (bool)auth()->user();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', 'min:3'],
+            'permissions' => ['array']
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,11 +8,12 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use LaravelAndVueJS\Traits\LaravelPermissionToVueJS;
 use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable, HasRoles;
+    use LaravelPermissionToVueJS, HasApiTokens, HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Policies/ReportPolicy.php
+++ b/app/Policies/ReportPolicy.php
@@ -90,7 +90,7 @@ class ReportPolicy
      */
     public function restore(User $user, Report $report): bool
     {
-        //
+        return false;
     }
 
     /**
@@ -98,6 +98,6 @@ class ReportPolicy
      */
     public function forceDelete(User $user, Report $report): bool
     {
-        //
+        return false;
     }
 }

--- a/app/Policies/ReportPolicy.php
+++ b/app/Policies/ReportPolicy.php
@@ -14,7 +14,15 @@ class ReportPolicy
      */
     public function viewAny(User $user): bool
     {
-        //
+        if ($user->can(PermissionsEnum::ACCESS_ALL_REPORTS->value)) {
+            return true;
+        }
+
+        if ($user->can(PermissionsEnum::ACCESS_OWN_REPORTS->value)){
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/app/Policies/ReportPolicy.php
+++ b/app/Policies/ReportPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Enums\PermissionsEnum;
 use App\Models\Report;
 use App\Models\User;
 use Illuminate\Auth\Access\Response;
@@ -21,7 +22,15 @@ class ReportPolicy
      */
     public function view(User $user, Report $report): bool
     {
-        //
+        if ($user->can(PermissionsEnum::ACCESS_ALL_REPORTS->value)) {
+            return true;
+        }
+
+        if ($user->can(PermissionsEnum::ACCESS_OWN_REPORTS->value)){
+            return $user->id === $report->user_id;
+        }
+
+        return false;
     }
 
     /**
@@ -29,7 +38,11 @@ class ReportPolicy
      */
     public function create(User $user): bool
     {
-        //
+        if ($user->can(PermissionsEnum::CREATE_REPORTS->value)) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -37,7 +50,15 @@ class ReportPolicy
      */
     public function update(User $user, Report $report): bool
     {
-        //
+        if ($user->can(PermissionsEnum::EDIT_ALL_REPORTS->value)) {
+            return true;
+        }
+
+        if ($user->can(PermissionsEnum::EDIT_OWN_REPORTS->value)){
+            return $user->id === $report->user_id;
+        }
+
+        return false;
     }
 
     /**
@@ -45,7 +66,15 @@ class ReportPolicy
      */
     public function delete(User $user, Report $report): bool
     {
-        //
+        if ($user->can(PermissionsEnum::DELETE_ALL_REPORTS->value)) {
+            return true;
+        }
+
+        if ($user->can(PermissionsEnum::DELETE_OWN_REPORTS->value)){
+            return $user->id === $report->user_id;
+        }
+
+        return false;
     }
 
     /**

--- a/app/Policies/RolePolicy.php
+++ b/app/Policies/RolePolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\PermissionsEnum;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+
+class RolePolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can(PermissionsEnum::ACCESS_ROLES->value);
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Role $role): bool
+    {
+        return $user->can(PermissionsEnum::ACCESS_ROLES->value);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can(PermissionsEnum::CREATE_ROLES->value);
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Role $role): bool
+    {
+        return $user->can(PermissionsEnum::EDIT_ROLES->value);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Role $role): bool
+    {
+        return $user->can(PermissionsEnum::DELETE_ROLES->value);
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Role $role): bool
+    {
+        return $user->can(PermissionsEnum::EDIT_ROLES->value);
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Role $role): bool
+    {
+        return $user->can(PermissionsEnum::DELETE_ROLES->value);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace App\Providers;
 
-// use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -21,6 +21,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::before(function ($user, $ability) {
+            return $user->hasRole('super-admin') ? true : null;
+        });
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,8 +2,12 @@
 
 namespace App\Providers;
 
+use App\Models\Report;
+use App\Policies\ReportPolicy;
+use App\Policies\RolePolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Spatie\Permission\Models\Role;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,7 +17,8 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        //
+        Report::class => ReportPolicy::class,
+        Role::class => RolePolicy::class,
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
+        "ahmedsaoud31/laravel-permission-to-vuejs": "dev-master",
         "barryvdh/laravel-dompdf": "^2.0",
         "dompdf/dompdf": "^2.0",
         "guzzlehttp/guzzle": "^7.2",

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "guzzlehttp/guzzle": "^7.2",
         "inertiajs/inertia-laravel": "^0.6.8",
         "laravel/framework": "^10.10",
+        "laravel/prompts": "^0.1.15",
         "laravel/sanctum": "^3.2",
         "laravel/tinker": "^2.8",
         "maatwebsite/excel": "^3.1",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "laravel/sanctum": "^3.2",
         "laravel/tinker": "^2.8",
         "maatwebsite/excel": "^3.1",
-        "spatie/laravel-permission": "^6.2",
+        "spatie/laravel-permission": "^6.3",
         "tightenco/ziggy": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "71aca2e2950a8bfac6c4221b05112777",
+    "content-hash": "723b0ab03bc56128537e4feb498bf147",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -4121,16 +4121,16 @@
         },
         {
             "name": "spatie/laravel-permission",
-            "version": "6.2.0",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-permission.git",
-                "reference": "299dd2c9bce700ea641021c1aea0dfece25e541d"
+                "reference": "4d119986c862ac0168b77338c85d8236bb559a88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/299dd2c9bce700ea641021c1aea0dfece25e541d",
-                "reference": "299dd2c9bce700ea641021c1aea0dfece25e541d",
+                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/4d119986c862ac0168b77338c85d8236bb559a88",
+                "reference": "4d119986c862ac0168b77338c85d8236bb559a88",
                 "shasum": ""
             },
             "require": {
@@ -4191,7 +4191,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-permission/issues",
-                "source": "https://github.com/spatie/laravel-permission/tree/6.2.0"
+                "source": "https://github.com/spatie/laravel-permission/tree/6.3.0"
             },
             "funding": [
                 {
@@ -4199,7 +4199,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-09T01:40:07+00:00"
+            "time": "2023-12-24T06:58:02+00:00"
         },
         {
             "name": "symfony/console",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,49 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "723b0ab03bc56128537e4feb498bf147",
+    "content-hash": "c857d6fd8cb418f53146c6b0ba6c94e5",
     "packages": [
+        {
+            "name": "ahmedsaoud31/laravel-permission-to-vuejs",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ahmedsaoud31/laravel-permission-to-vuejs.git",
+                "reference": "7c0d54d031cc84c3ed0ac9c356e2b15283e77145"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ahmedsaoud31/laravel-permission-to-vuejs/zipball/7c0d54d031cc84c3ed0ac9c356e2b15283e77145",
+                "reference": "7c0d54d031cc84c3ed0ac9c356e2b15283e77145",
+                "shasum": ""
+            },
+            "require": {
+                "spatie/laravel-permission": ">=2.0"
+            },
+            "default-branch": true,
+            "type": "plugin",
+            "autoload": {
+                "psr-4": {
+                    "LaravelAndVueJS\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ahmed Abeoelsaoud",
+                    "email": "ahmedsaoud31@gmail.com"
+                }
+            ],
+            "description": "Laravel Permission Package To Use it in VueJs",
+            "support": {
+                "issues": "https://github.com/ahmedsaoud31/laravel-permission-to-vuejs/issues",
+                "source": "https://github.com/ahmedsaoud31/laravel-permission-to-vuejs/tree/master"
+            },
+            "time": "2024-02-11T21:06:42+00:00"
+        },
         {
             "name": "barryvdh/laravel-dompdf",
             "version": "v2.0.1",
@@ -9299,7 +9340,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "ahmedsaoud31/laravel-permission-to-vuejs": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c857d6fd8cb418f53146c6b0ba6c94e5",
+    "content-hash": "c4f48977ae0dd76d83a4907b015230a3",
     "packages": [
         {
             "name": "ahmedsaoud31/laravel-permission-to-vuejs",
@@ -1643,16 +1643,16 @@
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.1.13",
+            "version": "v0.1.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "e1379d8ead15edd6cc4369c22274345982edc95a"
+                "reference": "d814a27514d99b03c85aa42b22cfd946568636c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/e1379d8ead15edd6cc4369c22274345982edc95a",
-                "reference": "e1379d8ead15edd6cc4369c22274345982edc95a",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/d814a27514d99b03c85aa42b22cfd946568636c1",
+                "reference": "d814a27514d99b03c85aa42b22cfd946568636c1",
                 "shasum": ""
             },
             "require": {
@@ -1668,7 +1668,7 @@
             "require-dev": {
                 "mockery/mockery": "^1.5",
                 "pestphp/pest": "^2.3",
-                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan": "^1.11",
                 "phpstan/phpstan-mockery": "^1.1"
             },
             "suggest": {
@@ -1694,9 +1694,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.1.13"
+                "source": "https://github.com/laravel/prompts/tree/v0.1.15"
             },
-            "time": "2023-10-27T13:53:59+00:00"
+            "time": "2023-12-29T22:37:42+00:00"
         },
         {
             "name": "laravel/sanctum",

--- a/database/seeders/AdminSeeder.php
+++ b/database/seeders/AdminSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class AdminSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        User::create([
+            'name' => "admin",
+            'email' => 'admin@example.com',
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ])->assignRole('super-admin');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,5 +18,7 @@ class DatabaseSeeder extends Seeder
         //     'name' => 'Test User',
         //     'email' => 'test@example.com',
         // ]);
+        $this->call(PermissionSeeder::class);
+        $this->call(AdminSeeder::class);
     }
 }

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class PermissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $roles = [
+            'super-admin',
+            'admin',
+            'user'
+        ];
+        $permissions = [
+            'create reports'=> ['super-admin','admin'],
+            'edit all reports'=> ['super-admin'],
+            'edit own reports'=> ['super-admin','admin'],
+            'delete own reports'=> ['super-admin','admin'],
+            'delete all reports'=> ['super-admin'],
+            'access permissions'=> ['super-admin'],
+            'assign permissions'=> ['super-admin'],
+            'access roles'=> ['super-admin'],
+            'create roles'=> ['super-admin'],
+            'edit roles'=> ['super-admin'],
+            'delete roles'=> ['super-admin'],
+            'assign roles'=> ['super-admin'],
+            'access role permissions'=> ['super-admin'],
+            'access user roles'=> ['super-admin'],
+            'access users'=> ['super-admin'],
+            'edit users'=> ['super-admin'],
+            'delete users'=> ['super-admin'],
+        ];
+        //create roles
+        foreach ($roles as $role) {
+            $rolesArray[$role] = Role::create(['name' => $role]);
+        }
+        //create permissions
+        foreach ($permissions as $permission => $authorized_roles) {
+            //create permission
+            Permission::create(['name' => $permission]);
+            //authorize roles to those permissions
+            foreach ($authorized_roles as $role) {
+                $rolesArray[$role]->givePermissionTo($permission);
+            }
+        }
+    }
+}

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -15,15 +15,17 @@ class PermissionSeeder extends Seeder
     {
         $roles = [
             'super-admin',
-            'admin',
             'user'
         ];
         $permissions = [
-            'create reports'=> ['super-admin','admin'],
+            'admin access'=> ['super-admin'],
+            'create reports'=> ['super-admin', 'user'],
             'edit all reports'=> ['super-admin'],
-            'edit own reports'=> ['super-admin','admin'],
-            'delete own reports'=> ['super-admin','admin'],
+            'edit own reports'=> ['super-admin','user'],
+            'delete own reports'=> ['super-admin','user'],
             'delete all reports'=> ['super-admin'],
+            'access own reports'=> ['super-admin', 'user'],
+            'access all reports'=> ['super-admin', 'user'],
             'access permissions'=> ['super-admin'],
             'assign permissions'=> ['super-admin'],
             'access roles'=> ['super-admin'],
@@ -36,7 +38,6 @@ class PermissionSeeder extends Seeder
             'access users'=> ['super-admin'],
             'edit users'=> ['super-admin'],
             'delete users'=> ['super-admin'],
-            'admin access'=> ['super-admin','admin'],
         ];
         //create roles
         foreach ($roles as $role) {

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -36,6 +36,7 @@ class PermissionSeeder extends Seeder
             'access users'=> ['super-admin'],
             'edit users'=> ['super-admin'],
             'delete users'=> ['super-admin'],
+            'admin access'=> ['super-admin','admin'],
         ];
         //create roles
         foreach ($roles as $role) {

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+//        Role::create(['name'=>'admin']);
+//        Role::create(['name'=>'user']);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "laravel-permission-to-vuejs": "^3.0.2"
+            },
             "devDependencies": {
                 "@inertiajs/vue3": "^1.0.0",
                 "@tailwindcss/forms": "^0.5.3",
@@ -1326,6 +1329,11 @@
             "bin": {
                 "jiti": "bin/jiti.js"
             }
+        },
+        "node_modules/laravel-permission-to-vuejs": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/laravel-permission-to-vuejs/-/laravel-permission-to-vuejs-3.0.2.tgz",
+            "integrity": "sha512-dI3tdP/91KCOgsBQlZqiH/tBiNhWYUDCW+tnxJiXce4Z4QNQuFVxgrQcKDKruJS503NPZC0A/K6gbOnU6FDqiw=="
         },
         "node_modules/laravel-vite-plugin": {
             "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
         "tailwindcss": "^3.2.1",
         "vite": "^4.0.0",
         "vue": "^3.2.41"
+    },
+    "dependencies": {
+        "laravel-permission-to-vuejs": "^3.0.2"
     }
 }

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -7,6 +7,7 @@ import NavLink from '@/Components/NavLink.vue';
 import ResponsiveNavLink from '@/Components/ResponsiveNavLink.vue';
 import {Link} from '@inertiajs/vue3';
 import PrimaryButton from "@/Components/PrimaryButton.vue";
+import SecondaryButton from "@/Components/SecondaryButton.vue";
 
 const showingNavigationDropdown = ref(false);
 </script>
@@ -33,7 +34,10 @@ const showingNavigationDropdown = ref(false);
                                 <NavLink :active="route().current('dashboard')" :href="route('dashboard')">
                                     Dashboard
                                 </NavLink>
-                                <NavLink :active="route().current('reports.index')" :href="route('reports.index')">
+                                <NavLink
+                                    :active="route().current('reports.index')" :href="route('reports.index')"
+                                    v-if="can('access own reports | access all reports')"
+                                >
                                     Reports
                                 </NavLink>
                                 <NavLink :active="route().current('attachments.index')"
@@ -45,11 +49,27 @@ const showingNavigationDropdown = ref(false);
                                 </NavLink>
                             </div>
                         </div>
-                        <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex justify-end flex-1 items-center">
-                            <div>
+                        <div
+                            class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex justify-end flex-1 items-center"
+                        >
+                            <div v-if="can('create reports')">
                                 <PrimaryButton :href="route('reports.create')">
                                     New Report
                                 </PrimaryButton>
+                            </div>
+                            <div v-if="can('admin access')">
+                                <Dropdown align="right" width="48">
+                                    <template #trigger>
+                                        <SecondaryButton class="ml-0">
+                                            Manage
+                                        </SecondaryButton>
+                                    </template>
+
+                                    <template #content>
+                                        <DropdownLink :href="route('roles.index')">Roles</DropdownLink>
+                                        <DropdownLink :href="route('permissions.index')">Permissions</DropdownLink>
+                                    </template>
+                                </Dropdown>
                             </div>
                         </div>
                         <div class="hidden sm:flex sm:items-center sm:ms-6">
@@ -119,12 +139,31 @@ const showingNavigationDropdown = ref(false);
                         <ResponsiveNavLink :active="route().current('dashboard')" :href="route('dashboard')">
                             Dashboard
                         </ResponsiveNavLink>
-                        <ResponsiveNavLink :active="route().current('reports.index')" :href="route('reports.index')">
+                        <ResponsiveNavLink
+                            :active="route().current('reports.index')" :href="route('reports.index')"
+                            v-if="can('access own reports | access all reports')"
+                        >
                             Reports
                         </ResponsiveNavLink>
                         <ResponsiveNavLink :active="route().current('attachments.index')"
                                            :href="route('attachments.index')">
                             Attachments
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink :active="route().current('tags.index')"
+                                           :href="route('tags.index')">
+                            Tags
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink :active="route().current('roles.index')"
+                                           :href="route('roles.index')"
+                                           v-if="can('admin access')"
+                        >
+                            Roles
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink :active="route().current('permissions.index')"
+                                           :href="route('permissions.index')"
+                                           v-if="can('admin access')"
+                        >
+                            Permissions
                         </ResponsiveNavLink>
                     </div>
 

--- a/resources/js/Pages/Permissions/Index.vue
+++ b/resources/js/Pages/Permissions/Index.vue
@@ -1,0 +1,67 @@
+<script setup>
+
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
+import {Head} from "@inertiajs/vue3";
+
+defineProps({
+    permissions : Object,
+});
+</script>
+
+
+<template>
+    <Head title="Permissions"/>
+    <AuthenticatedLayout>
+        <template #header>
+            <div class="flex flex-row ">
+                <h2 class="font-semibold text-xl text-gray-800 leading-tight">Permissions</h2>
+            </div>
+        </template>
+        <div class="m-auto">
+            <div class="bg-skin-base overflow-hidden  sm:rounded-lg p-2">
+                <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                    <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+                        <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg border bg-white">
+                            <table class="min-w-full divide-y divide-gray-200 sm:rounded-lg">
+                                <thead class="bg-gray-50 font-medium text-left">
+                                <tr>
+                                    <th class="px-6 py-4 uppercase tracking-wider" scope="col">
+                                        #
+                                    </th>
+                                    <th class="px-6 py-4 uppercase tracking-wider" scope="col">
+                                        Name
+                                    </th>
+                                    <th class="px-6 py-4 uppercase tracking-wider" scope="col">
+                                        Guard
+                                    </th>
+                                    <th class="px-6 py-4 uppercase tracking-wider" scope="col">
+                                        Roles
+                                    </th>
+                                </tr>
+                                </thead>
+                                <tbody class="bg-skin-base divide-y divide-gray-200 text-gray-600">
+                                <template v-for="(permission, index) in permissions" :key="permission.id">
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            {{ index+1 }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            {{ permission.name }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            {{ permission.guard_name }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            {{ permission.roles_count }}
+                                        </td>
+                                    </tr>
+                                </template>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Reports/Index.vue
+++ b/resources/js/Pages/Reports/Index.vue
@@ -124,10 +124,13 @@ let showFilters = ref(String(props.filters.showFilters).toLowerCase() === 'true'
                                             <SecondaryButton
                                                 :href="route('reports.edit', report.id)"
                                                 class="ml-2"
+                                                v-if="can('edit own reports | edit all reports')"
                                             >
                                                 Edit
                                             </SecondaryButton>
-                                            <DeleteReportForm :key="report.id" :report="report" class="ml-2"/>
+                                            <DeleteReportForm
+                                                v-if="can('delete own reports | delete all reports')"
+                                                :key="report.id" :report="report" class="ml-2"/>
                                         </td>
 
                                     </tr>

--- a/resources/js/Pages/Reports/Partials/CreateReportForm.vue
+++ b/resources/js/Pages/Reports/Partials/CreateReportForm.vue
@@ -141,7 +141,7 @@ const searchTags = async (search) => {
             <InputError :message="form.errors.status" class="mt-2"/>
         </div>
 
-        <div class="flex items-center justify-end mt-4">
+        <div class="flex items-center justify-end mt-4"  v-if="can('create reports')">
             <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing" class="ms-4">
                 Create Report
             </PrimaryButton>

--- a/resources/js/Pages/Reports/Partials/UpdateReportForm.vue
+++ b/resources/js/Pages/Reports/Partials/UpdateReportForm.vue
@@ -49,7 +49,7 @@ const searchTags = async (search) => {
 </script>
 
 <template>
-    <Head title="New Report"/>
+    <Head title="Edit Report"/>
 
     <form @submit.prevent="submit">
         <div>
@@ -143,7 +143,7 @@ const searchTags = async (search) => {
             <InputError :message="form.errors.status" class="mt-2"/>
         </div>
 
-        <div class="flex items-center justify-end mt-4">
+        <div class="flex items-center justify-end mt-4" v-if="can('edit own reports | edit all reports')">
             <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing" class="ms-4">
                 Update Report
             </PrimaryButton>

--- a/resources/js/Pages/Roles/Create.vue
+++ b/resources/js/Pages/Roles/Create.vue
@@ -1,0 +1,29 @@
+<script setup>
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
+import {Head} from "@inertiajs/vue3";
+import CreateRoleForm from "@/Pages/Roles/Partials/CreateRoleForm.vue";
+
+const props = defineProps({
+    permissions: {
+        type: Array,
+    },
+})
+</script>
+
+<template>
+    <Head title="New Role"/>
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Create Role</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+                <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                    <CreateRoleForm :permissions="permissions" class="max-w-xl"/>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Roles/Edit.vue
+++ b/resources/js/Pages/Roles/Edit.vue
@@ -1,0 +1,32 @@
+<script setup>
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
+import {Head} from "@inertiajs/vue3";
+import UpdateRoleForm from "@/Pages/Roles/Partials/UpdateRoleForm.vue";
+
+defineProps({
+    role: {
+        type: Object,
+    },
+    permissions: {
+        type: Array,
+    },
+})
+</script>
+
+<template>
+    <Head title="Edit Role"/>
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Edit Role - {{ role.name }}</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto sm:px-6 lg:px-8 space-y-6">
+                <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                    <UpdateRoleForm :permissions="permissions" :role="role"/>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Roles/Index.vue
+++ b/resources/js/Pages/Roles/Index.vue
@@ -1,0 +1,91 @@
+<script setup>
+
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
+import {Head, Link} from "@inertiajs/vue3";
+import PrimaryButton from "@/Components/PrimaryButton.vue";
+import SecondaryButton from "@/Components/SecondaryButton.vue";
+import DeleteRoleForm from "@/Pages/Roles/Partials/DeleteRoleForm.vue";
+
+defineProps({
+    roles: Object
+});
+</script>
+
+
+<template>
+    <Head title="Permissions"/>
+    <AuthenticatedLayout>
+        <template #header>
+            <div class="flex flex-row ">
+                <h2 class="font-semibold text-xl text-gray-800 leading-tight">Roles</h2>
+                <div class="flex-1 flex justify-end">
+                    <PrimaryButton :href="route('roles.create')" class="ml-2">
+                        New Role
+                    </PrimaryButton>
+                </div>
+            </div>
+        </template>
+        <div class="m-auto">
+            <div class="bg-skin-base overflow-hidden  sm:rounded-lg p-2">
+                <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                    <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+                        <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg border bg-white">
+                            <table class="min-w-full divide-y divide-gray-200 sm:rounded-lg">
+                                <thead class="bg-gray-50 font-medium text-left">
+                                <tr>
+                                    <th class="px-6 py-4 uppercase tracking-wider" scope="col">
+                                        #
+                                    </th>
+                                    <th class="px-6 py-4 uppercase tracking-wider" scope="col">
+                                        Name
+                                    </th>
+                                    <th class="px-6 py-4 uppercase tracking-wider" scope="col">
+                                        Guard
+                                    </th>
+                                    <th class="px-6 py-4 uppercase tracking-wider" scope="col">
+                                        Users
+                                    </th>
+                                    <th class="relative px-6 py-4" scope="col">
+                                        <span class="sr-only">Actions</span>
+                                    </th>
+                                </tr>
+                                </thead>
+                                <tbody class="bg-skin-base divide-y divide-gray-200 text-gray-600">
+                                <template v-for="(role, index) in roles" :key="role.id">
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            {{ index+1 }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            <Link
+                                                :href="route('roles.show', role.id)"
+                                            >
+                                                {{ role.name }}
+                                            </Link>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            {{ role.guard_name }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            {{ role.users_count }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium flex flex-row">
+                                            <SecondaryButton
+                                                :href="route('roles.edit', role.id)"
+                                                class="ml-2"
+                                            >
+                                                Edit
+                                            </SecondaryButton>
+                                            <DeleteRoleForm :key="role.id" :role="role" class="ml-2"/>
+                                        </td>
+                                    </tr>
+                                </template>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Roles/Partials/CreateRoleForm.vue
+++ b/resources/js/Pages/Roles/Partials/CreateRoleForm.vue
@@ -1,0 +1,78 @@
+<script setup>
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import {Head, useForm} from '@inertiajs/vue3';
+import MultiSelectInput from "@/Components/MultiSelectInput.vue";
+
+const props = defineProps({
+    permissions: {
+        type: Array,
+    }
+});
+
+const form = useForm({
+    name: '',
+    permissions: []
+});
+
+const submit = () => {
+    form.post(route('roles.store'));
+};
+
+
+const searchPermissions = async (search) => {
+    const filteredPermissions = props.permissions.filter(permission => {
+        return permission.name.includes(search);
+    });
+
+    return filteredPermissions.map(permission => {
+        return {
+            'key': permission.id,
+            'value': permission.name
+        };
+    });
+};
+</script>
+
+<template>
+    <Head title="New Report"/>
+
+    <form @submit.prevent="submit">
+        <div>
+            <InputLabel for="name" value="Name"/>
+
+            <TextInput
+                id="name"
+                v-model="form.name"
+                autocomplete="name"
+                autofocus
+                class="mt-1 block w-full"
+                type="text"
+            />
+
+            <InputError :message="form.errors.name" class="mt-2"/>
+        </div>
+
+        <div class="mt-4">
+            <InputLabel for="permissions" value="Permissions"/>
+
+            <MultiSelectInput
+                id="permissions"
+                v-model="form.permissions"
+                :search-function="searchPermissions"
+                autocomplete="permissions"
+                class="mt-1 block w-full"
+            />
+
+            <InputError :message="form.errors.tags" class="mt-2"/>
+        </div>
+
+        <div class="flex items-center justify-end mt-4">
+            <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing" class="ms-4">
+                Create Role
+            </PrimaryButton>
+        </div>
+    </form>
+</template>

--- a/resources/js/Pages/Roles/Partials/DeleteRoleForm.vue
+++ b/resources/js/Pages/Roles/Partials/DeleteRoleForm.vue
@@ -1,0 +1,58 @@
+<script setup>
+import DangerButton from '@/Components/DangerButton.vue';
+import Modal from '@/Components/Modal.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import {useForm} from '@inertiajs/vue3';
+import {ref} from 'vue';
+
+const props = defineProps({
+    role: {
+        type: Object,
+    }
+})
+const confirmingRoleDeletion = ref(false);
+const form = useForm({});
+const confirmRoleDeletion = () => {
+    confirmingRoleDeletion.value = true;
+};
+
+const deleteRole = () => {
+    form.delete(route('roles.destroy', props.role.id),{
+        preserveScroll: true,
+        onSuccess: () => closeModal(),
+        onFinish: () => form.reset(),
+    });
+};
+
+const closeModal = () => {
+    confirmingRoleDeletion.value = false;
+
+    form.reset();
+};
+</script>
+
+<template>
+    <section class="space-y-6">
+        <DangerButton @click="confirmRoleDeletion">Delete</DangerButton>
+
+        <Modal :show="confirmingRoleDeletion" @close="closeModal">
+            <div class="p-6">
+                <h2 class="text-lg font-medium text-gray-900">
+                    Are you sure you want to delete the role - <span class="font-bold">{{ role.name }}</span>?
+                </h2>
+                <div class="mt-6 flex justify-end">
+                    <SecondaryButton @click="closeModal"> Cancel</SecondaryButton>
+
+                    <DangerButton
+                        :class="{ 'opacity-25': form.processing }"
+                        :disabled="form.processing"
+                        class="ms-3"
+                        @click="deleteRole"
+                    >
+                        Delete Role
+                    </DangerButton>
+                </div>
+            </div>
+        </Modal>
+    </section>
+</template>

--- a/resources/js/Pages/Roles/Partials/UpdateRoleForm.vue
+++ b/resources/js/Pages/Roles/Partials/UpdateRoleForm.vue
@@ -1,0 +1,80 @@
+<script setup>
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import {Head, useForm} from '@inertiajs/vue3';
+import MultiSelectInput from "@/Components/MultiSelectInput.vue";
+
+const props = defineProps({
+    role: {
+        type: Object,
+    },
+    permissions: {
+        type: Array,
+    }
+});
+
+const form = useForm({
+    name: props.role.name,
+    permissions: props.role.permissions.map(permission => permission.name),
+});
+
+const submit = () => {
+    form.put(route('roles.update', props.role.id));
+};
+
+const searchPermissions = async (search) => {
+    const filteredPermissions = props.permissions.filter(permission => {
+        return permission.name.includes(search);
+    });
+
+    return filteredPermissions.map(permission => {
+        return {
+            'key': permission.id,
+            'value': permission.name
+        };
+    });
+};
+</script>
+
+<template>
+    <Head title="New Role"/>
+
+    <form @submit.prevent="submit">
+        <div>
+            <InputLabel for="name" value="Name"/>
+
+            <TextInput
+                id="name"
+                v-model="form.name"
+                autocomplete="name"
+                autofocus
+                class="mt-1 block w-full"
+                type="text"
+            />
+
+            <InputError :message="form.errors.name" class="mt-2"/>
+        </div>
+
+        <div class="mt-4">
+            <InputLabel for="permissions" value="Permissions"/>
+
+            <MultiSelectInput
+                id="permissions"
+                v-model="form.permissions"
+                :search-function="searchPermissions"
+                autocomplete="permissions"
+                class="mt-1 block w-full"
+            />
+
+            <InputError :message="form.errors.tags" class="mt-2"/>
+        </div>
+
+        <div class="flex items-center justify-end mt-4">
+            <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing" class="ms-4">
+                Update Role
+            </PrimaryButton>
+        </div>
+    </form>
+</template>

--- a/resources/js/Pages/Roles/Show.vue
+++ b/resources/js/Pages/Roles/Show.vue
@@ -1,0 +1,70 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import {Head} from '@inertiajs/vue3';
+import SecondaryButton from "@/Components/SecondaryButton.vue";
+import Tag from "@/Components/Tag.vue";
+import DeleteRoleForm from "@/Pages/Roles/Partials/DeleteRoleForm.vue";
+
+defineProps({
+    role: Object,
+});
+</script>
+
+<template>
+    <Head :title="role.name"/>
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Role - {{ role.name }}</h2>
+            <div class="flex-1 flex justify-end">
+                <SecondaryButton :href="route('roles.edit', role.id)" class="ml-2">
+                    Edit Role
+                </SecondaryButton>
+                <DeleteRoleForm :key="role.id" :role="role" class="ml-2"/>
+            </div>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto sm:px-6 lg:px-8 space-y-6">
+                <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                    <h2 class="font-semibold text-xl text-gray-800 leading-tight">Role Details</h2>
+                    <div>
+                        <div class="py-4 grid grid-cols-2 gap-4">
+                            <div class="flex flex-col">
+                                <label class="block text-sm font-medium text-gray-700" for="name">Name</label>
+                                <div class="mt-1">
+                                    <input id="name" :value="role.name"
+                                           class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                                           name="name"
+                                           readonly
+                                           type="text">
+                                </div>
+                            </div>
+                            <div class="flex flex-col">
+                                <label class="block text-sm font-medium text-gray-700"
+                                       for="guard">Guard</label>
+                                <div class="mt-1">
+                                    <input id="guard"
+                                              class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                                              name="guard"
+                                              readonly
+                                              :value="role.guard_name"
+                                              type="text">
+                                </div>
+                            </div>
+                            <div class="flex flex-col">
+                                <p class="block text-sm font-medium text-gray-700">Permissions</p>
+                                <div class="mt-1">
+                                    <template v-for="permission in role.permissions">
+                                        <Tag :value="permission.name" />
+                                    </template>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>
+

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,6 +6,7 @@ import {createInertiaApp} from '@inertiajs/vue3';
 import {resolvePageComponent} from 'laravel-vite-plugin/inertia-helpers';
 import {ZiggyVue} from '../../vendor/tightenco/ziggy/dist/vue.m';
 import {clickoutDirective} from "@/directives.js";
+import LaravelPermissionToVueJS from 'laravel-permission-to-vuejs'
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -16,6 +17,7 @@ createInertiaApp({
         return createApp({render: () => h(App, props)})
             .use(plugin)
             .use(ZiggyVue, Ziggy)
+            .use(LaravelPermissionToVueJS)
             .directive('clickout', clickoutDirective)
             .mount(el);
     },

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -15,7 +15,6 @@
                 csrfToken: "{{ csrf_token() }}",
                 jsPermissions: {!! auth()->check()?auth()->user()->jsPermissions():0 !!}
             }
-            console.log(window.Laravel.jsPermissions)
         </script>
 
         <!-- Scripts -->

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -10,6 +10,14 @@
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
+        <script type="text/javascript">
+            window.Laravel = {
+                csrfToken: "{{ csrf_token() }}",
+                jsPermissions: {!! auth()->check()?auth()->user()->jsPermissions():0 !!}
+            }
+            console.log(window.Laravel.jsPermissions)
+        </script>
+
         <!-- Scripts -->
         @routes
         @vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Http\Controllers\Admin\RoleController;
 use App\Http\Controllers\AttachmentController;
+use \App\Http\Controllers\Admin\PermissionController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ReportController;
@@ -27,11 +29,16 @@ Route::get('/', function () {
         'laravelVersion' => Application::VERSION,
         'phpVersion' => PHP_VERSION,
     ]);
-});
+})->name('home');
 
 Route::get('/dashboard', function () {
     return Inertia::render('Dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
+
+Route::middleware(['auth', 'admin'])->prefix("manage")->group(function (){
+    Route::resource('roles', RoleController::class);
+    Route::get('permissions', [PermissionController::class, 'index'])->name('permissions.index');
+});
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
For now, there are only two roles: `super-admin` and `user` (which can be populated by running the `PermissionSeeder`).

However, the `super-admin` has the capability to create new roles and assign permissions to those roles.

Below are the available permissions (not editable) that can be assigned to roles:

- `ADMIN_ACCESS`: Grants access to administrative features.
- `ACCESS_USERS`: Allows access to user management functionalities.
- `CREATE_USERS`: Permits the creation of new user accounts.
- `EDIT_USERS`: Enables the editing of existing user accounts.
- `DELETE_USERS`: Allows the deletion of user accounts.
- `ACCESS_ALL_REPORTS`: Grants access to view all reports.
- `ACCESS_OWN_REPORTS`: Grants access to view own reports.
- `CREATE_REPORTS`: Permits the creation of new reports.
- `EDIT_ALL_REPORTS`: Allows the editing of all reports.
- `EDIT_OWN_REPORTS`: Enables the editing of own reports.
- `DELETE_ALL_REPORTS`: Allows the deletion of all reports.
- `DELETE_OWN_REPORTS`: Permits the deletion of own reports.
- `ACCESS_ROLES`: Grants access to role management functionalities.
- `CREATE_ROLES`: Permits the creation of new roles.
- `EDIT_ROLES`: Allows the editing of existing roles.
- `DELETE_ROLES`: Permits the deletion of roles.
- `ASSIGN_ROLES`: Enables the assignment of roles to users.
- `ACCESS_PERMISSIONS`: Grants access to permission management functionalities.
- `ASSIGN_PERMISSIONS`: Enables the assignment of permissions to roles.

Additionally, it adds a command `user:create` which can be used to create users with specific roles.
